### PR TITLE
handle single status field correctly

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,7 +41,7 @@ jQuery(function () {
      * Set the statuses accrding to the given set
      *
      * @param {jQuery} $full the wrapper around the statuses
-     * @param {int[]} set the list of statuses to enable
+     * @param {int|int[]} set the status or the list of statuses to enable
      */
     function applyDataSet($full, set) {
         $full.find('div.struct_status').each(function () {

--- a/script.js
+++ b/script.js
@@ -45,6 +45,9 @@ jQuery(function () {
      */
     function applyDataSet($full, set) {
         $full.find('div.struct_status').each(function () {
+            if(typeof set == 'number') {
+                set = [set];
+            }
             var $self = jQuery(this);
             if (set.indexOf($self.data('pid')) === -1) {
                 $self.addClass('disabled');


### PR DESCRIPTION
If status is not a multi-field but a single field in the schema, then `set`, as returned
by `makeDataSet()` is only the number of the single status to be toggled
on.