### PR TITLE
Fix: Initialize set on single status deselect

### DIFF
--- a/script.js
+++ b/script.js
@@ -45,7 +45,10 @@ jQuery(function () {
      */
     function applyDataSet($full, set) {
         $full.find('div.struct_status').each(function () {
-            if(typeof set == 'number') {
+            if (typeof set == 'undefined') {
+                set = [];
+            }
+            if (typeof set == 'number') {
                 set = [set];
             }
             var $self = jQuery(this);


### PR DESCRIPTION
If we deselect the single status, then we get as `set` an undefined value.
We need to reinitialize this to an empty array.