### PR TITLE
Change clickable <div> into <button>, for accessibility

### DIFF
--- a/Status.php
+++ b/Status.php
@@ -45,18 +45,21 @@ class Status extends Lookup {
      * @param string $icon
      * @param string $pid the identifier in the linked status lookup table
      * @param array $classes
+     * @param bool  $button
      * @return string
      */
-    public function xhtmlStatus($label, $color, $icon='', $pid='', $classes=array()) {
+    public function xhtmlStatus($label, $color, $icon='', $pid='', $classes=array(), $button=false) {
         $html = '';
         $classes[] = 'struct_status';
         if($icon) $classes[] = 'struct_status_icon_'.$icon;
         $class = hsc(join(' ', $classes));
 
-        $html .= '<div class="' . $class . '" style="border-color:' . hsc($color) . '; fill: ' . hsc($color) . ';" data-pid="'.hsc($pid).'">';
+        $tag = $button ? 'button' : 'div';
+
+        $html .= "<$tag class=\"" . $class . '" style="border-color:' . hsc($color) . '; fill: ' . hsc($color) . ';" data-pid="'.hsc($pid).'">';
         $html .= $this->inlineSVG($icon);
         $html .= hsc($label);
-        $html .= '</div>';
+        $html .= "</$tag>";
 
         return $html;
     }

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ jQuery(function () {
     /**
      * Attach the click handler
      */
-    jQuery('.structstatus-full.editable').find('div.struct_status')
+    jQuery('.structstatus-full.editable').find('button.struct_status')
         .click(function () {
             var $self = jQuery(this);
             $self.parent().css('visibility', 'hidden');
@@ -34,7 +34,6 @@ jQuery(function () {
             ;
 
         })
-        .css('cursor', 'pointer')
     ;
 
     /**
@@ -44,7 +43,7 @@ jQuery(function () {
      * @param {int|int[]} set the status or the list of statuses to enable
      */
     function applyDataSet($full, set) {
-        $full.find('div.struct_status').each(function () {
+        $full.find('button.struct_status').each(function () {
             if (typeof set == 'undefined') {
                 set = [];
             }
@@ -71,7 +70,7 @@ jQuery(function () {
         var set = [];
         var wason = false;
 
-        $full.find('div.struct_status').not('.disabled').each(function () {
+        $full.find('button.struct_status').not('.disabled').each(function () {
             var pid = jQuery(this).data('pid');
             if (pid === toggle) {
                 wason = true; // this is the value we're toggling

--- a/style.less
+++ b/style.less
@@ -1,4 +1,4 @@
-.dokuwiki div.struct_status {
+.dokuwiki .struct_status {
     border: 1px solid @ini_bordercolor;
     border-radius: 3px;
     white-space: nowrap;
@@ -20,8 +20,11 @@
 
     font-size: (100% * @factor);
 
-    div.struct_status {
+    button.struct_status {
         display: block;
+        width: 100%;
+        text-align: left;
+        background: inherit;
 
         svg {
             width: (14px * @factor);
@@ -29,12 +32,12 @@
         }
     }
 
-    div.struct_status.disabled {
+    button.struct_status.disabled {
         filter: grayscale(100%);
         opacity: 0.2;
     }
 
-    div.struct_status.disabled:hover {
+    button.struct_status.disabled:hover {
         opacity: 0.6;
     }
 }

--- a/syntax.php
+++ b/syntax.php
@@ -127,7 +127,7 @@ class syntax_plugin_structstatus extends DokuWiki_Syntax_Plugin {
             } else {
                 $class = array('disabled');
             }
-            $html .= $type->xhtmlStatus($status['label'], $color, $status['icon'], $status['pid'], $class);
+            $html .= $type->xhtmlStatus($status['label'], $color, $status['icon'], $status['pid'], $class, true);
         }
         $html .= '</div>';
 


### PR DESCRIPTION
For semantic correctness and compatibility with screen-readers, etc., we should not use `<div>`s, that behave like buttons, but `<button>`s.

SPR-873