### PR TITLE
fix: the guaranteed placeholder is __border__

### DIFF
--- a/style.less
+++ b/style.less
@@ -1,5 +1,5 @@
 .dokuwiki .struct_status {
-    border: 1px solid @ini_bordercolor;
+    border: 1px solid @ini_border;
     border-radius: 3px;
     white-space: nowrap;
     display: inline-block;


### PR DESCRIPTION
the guaranteed placeholder in `lib/tpl/dokuwiki/style.ini` is `__border__` and hence `@ini_border`