### PR TITLE
Adjust the plugin to work with struct 2020-05-12 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@
 
 language: php
 php:
-  - "7.0"
-  - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
+    - "nightly"
+    - "7.3"
+    - "7.2"
+    - "7.1"
+    - "7.0"
+    - "5.6"
 env:
-  - DOKUWIKI=master
-  - DOKUWIKI=stable
+    matrix:
+        - DOKUWIKI=master
+        - DOKUWIKI=stable
+matrix:
+    allow_failures:
+        - php: "nightly"
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
-script: cd _test && phpunit --stderr --group plugin_structstatus
+script: cd _test && ./phpunit.phar --stderr --group plugin_structstatus

--- a/Status.php
+++ b/Status.php
@@ -2,6 +2,7 @@
 
 namespace dokuwiki\plugin\structstatus;
 
+use dokuwiki\plugin\struct\meta\Column;
 use dokuwiki\plugin\struct\meta\QueryBuilder;
 use dokuwiki\plugin\struct\meta\Search;
 use dokuwiki\plugin\struct\types\AbstractBaseType;
@@ -43,12 +44,12 @@ class Status extends Lookup {
      * @param string $label
      * @param string $color
      * @param string $icon
-     * @param string $pid the identifier in the linked status lookup table
+     * @param string $rid the identifier in the linked status lookup table
      * @param array $classes
      * @param bool  $button
      * @return string
      */
-    public function xhtmlStatus($label, $color, $icon='', $pid='', $classes=array(), $button=false) {
+    public function xhtmlStatus($label, $color, $icon='', $rid = 0, $classes=array(), $button=false) {
         $html = '';
         $classes[] = 'struct_status';
         if($icon) $classes[] = 'struct_status_icon_'.$icon;
@@ -56,7 +57,7 @@ class Status extends Lookup {
 
         $tag = $button ? 'button' : 'div';
 
-        $html .= "<$tag class=\"" . $class . '" style="border-color:' . hsc($color) . '; fill: ' . hsc($color) . ';" data-pid="'.hsc($pid).'">';
+        $html .= "<$tag class=\"" . $class . '" style="border-color:' . hsc($color) . '; fill: ' . hsc($color) . ';" data-rid="'.hsc($rid).'">';
         $html .= $this->inlineSVG($icon);
         $html .= hsc($label);
         $html .= "</$tag>";
@@ -157,16 +158,16 @@ class Status extends Lookup {
         $search->addColumn('icon');
         $search->addSort($colname);
         $values = $search->execute();
-        $pids = $search->getPids();
+        $rids = $search->getRids();
 
         $statuses = array();
         foreach($values as $status) {
-            $pid = array_shift($pids);
+            $rid = json_encode(["", (int)array_shift($rids)]);
             $label = $status[0]->getValue();
             $color = $status[1]->getValue();
             $icon = $status[2]->getValue();
 
-            $statuses[] = compact('pid', 'label', 'color', 'icon');
+            $statuses[] = compact('rid', 'label', 'color', 'icon');
         }
 
         return $statuses;

--- a/Status.php
+++ b/Status.php
@@ -132,7 +132,7 @@ class Status extends Lookup {
         // join the lookup
         $QB->addLeftJoin(
             $tablealias, $schema, $rightalias,
-            "$tablealias.$colname = $rightalias.pid AND $rightalias.latest = 1"
+            "$tablealias.$colname = STRUCT_JSON($rightalias.pid, CAST($rightalias.rid AS DECIMAL)) AND $rightalias.latest = 1"
         );
 
         // get the values (pid, status, color)

--- a/script.js
+++ b/script.js
@@ -4,15 +4,17 @@ jQuery(function () {
      */
     jQuery('.structstatus-full.editable').find('button.struct_status')
         .click(function () {
-            var $self = jQuery(this);
+            const $self = jQuery(this);
             $self.parent().css('visibility', 'hidden');
 
-            var set = makeDataSet($self.parent(), $self.data('pid'));
+            const set = makeDataSet($self.parent(), $self.data('rid'));
 
-            var data = {
+            const data = {
                 sectok: $self.parent().data('st'),
                 field: $self.parent().data('field'),
                 pid: $self.parent().data('page'),
+                rid: $self.parent().data('rid'),
+                rev: $self.parent().data('rev'),
                 entry: set,
                 call: 'plugin_struct_inline_save'
             };
@@ -25,8 +27,9 @@ jQuery(function () {
                     alert(jqXHR.responseText);
                 })
                 .success(function (response) {
+                    const value = JSON.parse(response).value;
                     applyDataSet($self.parent(), set);
-                    jQuery('#plugin__struct_output').find('td[data-struct="'+ $self.parent().data('field') +'"]').html(response);
+                    jQuery('#plugin__struct_output').find('td[data-struct="' + $self.parent().data('field') + '"]').html(value);
                 })
                 .done(function () {
                     $self.parent().css('visibility', 'visible');
@@ -37,21 +40,18 @@ jQuery(function () {
     ;
 
     /**
-     * Set the statuses accrding to the given set
+     * Set the statuses according to the given set
      *
      * @param {jQuery} $full the wrapper around the statuses
-     * @param {int|int[]} set the status or the list of statuses to enable
+     * @param {Array} set the status or the list of statuses to enable
      */
     function applyDataSet($full, set) {
         $full.find('button.struct_status').each(function () {
             if (typeof set == 'undefined') {
                 set = [];
             }
-            if (typeof set == 'number') {
-                set = [set];
-            }
-            var $self = jQuery(this);
-            if (set.indexOf($self.data('pid')) === -1) {
+            const $self = jQuery(this);
+            if (set.indexOf(JSON.stringify($self.data('rid'))) === -1) {
                 $self.addClass('disabled');
             } else {
                 $self.removeClass('disabled');
@@ -63,19 +63,19 @@ jQuery(function () {
      * Create a set based on the current set and the status to toggle
      *
      * @param {jQuery} $full the wrapper around the statuses
-     * @param {int} toggle the pid of the status to toggle
-     * @return {int|int[]} the resulting new set
+     * @param {[]} toggle the rid of the status to toggle
+     * @return {Array} the resulting new set
      */
     function makeDataSet($full, toggle) {
-        var set = [];
-        var wason = false;
+        const set = [];
+        let wason = false;
 
         $full.find('button.struct_status').not('.disabled').each(function () {
-            var pid = jQuery(this).data('pid');
-            if (pid === toggle) {
+            const rid = jQuery(this).data('rid');
+            if (rid === toggle) {
                 wason = true; // this is the value we're toggling
             } else {
-                set.push(pid); // this is an enabled value we keep
+                set.push(rid); // this is an enabled value we keep
             }
         });
         if (!wason) {
@@ -84,10 +84,11 @@ jQuery(function () {
 
         // for non-multi field only one value is allowed
         if (!$full.data('multi')) {
-            return set.pop();
+            return [JSON.stringify(set.pop())];
         }
-        return set;
+
+        return set.map(function (entry) {
+            return JSON.stringify(entry);
+        });
     }
-
-
 });


### PR DESCRIPTION
The current versions of struct store and handle references to Lookup data differently, replacing the `pid` identifier with JSON encoded combination of `pid` and `rid`.

The first step towards restoring compatibility is to fetch and save data using the new data identifier. This is what the first commit in this PR does.

But the status widget is still broken, as it needs more comprehensive re-work. 